### PR TITLE
Add a muse configuration

### DIFF
--- a/.muse.toml
+++ b/.muse.toml
@@ -1,0 +1,1 @@
+build = "mvn compile"


### PR DESCRIPTION
Hello, I work at MuseDev and saw this project pop up in our logs. It appears the build failed - fortunately the failure is easy to fix by specifying `build = "mvn compile"` (it defaults to `package`).

With this configuration, any pull requests will be analyzed and new bugs will be surfaced as comments.  Any false positives won't receive comments going forward but you always have access to the complete list of issues discovered via the console (ex: https://console.muse.dev/result/TomMD/micro-integrator/01EF4VKNJ58CETWKKTR1PZDY7Z?tab=results).

If you have any questions before installing the app on the wso2 account then please do reach out here or via the support form, I'd be happy to chat.